### PR TITLE
feat: gate local download starts by time window

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,8 +238,14 @@ folder: "plundrio"             # Folder name on put.io
 token: ""                      # Put.io OAuth token (prefer env var)
 listen: ":9091"                # Transmission RPC server address
 workers: 4                     # Number of download workers
+download_start_window:         # Optional local download start window
+  enabled: false
+  start: "23:00"
+  end: "05:00"
 log_level: "info"              # Log level (trace,debug,info,warn,error,fatal,panic,none,pretty)
 ```
+
+`download_start_window` only gates when plundrio may begin a new local download. It does not stop Put.io transfers from being created, and it does not interrupt downloads that are already in progress.
 
 2. **Command-line flags** (see full list with `plundrio run --help`)
 
@@ -251,6 +257,9 @@ export PLDR_TOKEN=your-putio-token
 export PLDR_FOLDER=plundrio
 export PLDR_LISTEN=:9091
 export PLDR_WORKERS=4
+export PLDR_DOWNLOAD_START_WINDOW_ENABLED=true
+export PLDR_DOWNLOAD_START_WINDOW_START=23:00
+export PLDR_DOWNLOAD_START_WINDOW_END=05:00
 export PLDR_LOG_LEVEL=info
 ```
 

--- a/cmd/plundrio/main.go
+++ b/cmd/plundrio/main.go
@@ -35,6 +35,7 @@ var runCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// Initialize Viper
 		viper.SetEnvPrefix("PLDR")
+		viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
 		viper.AutomaticEnv()
 
 		configFile, _ := cmd.Flags().GetString("config")
@@ -66,12 +67,20 @@ var runCmd = &cobra.Command{
 		oauthToken := viper.GetString("token")
 		listenAddr := viper.GetString("listen")
 		workerCount := viper.GetInt("workers")
+		downloadStartWindow := config.DownloadStartWindowConfig{
+			Enabled: viper.GetBool("download_start_window.enabled"),
+			Start:   viper.GetString("download_start_window.start"),
+			End:     viper.GetString("download_start_window.end"),
+		}
 
 		log.Debug("config").
 			Str("target_dir", targetDir).
 			Str("putio_folder", putioFolder).
 			Str("listen_addr", listenAddr).
 			Int("workers", workerCount).
+			Bool("download_start_window_enabled", downloadStartWindow.Enabled).
+			Str("download_start_window_start", downloadStartWindow.Start).
+			Str("download_start_window_end", downloadStartWindow.End).
 			Msg("Configuration loaded")
 
 		// Validate required configuration values
@@ -102,11 +111,16 @@ var runCmd = &cobra.Command{
 
 		// Initialize configuration
 		cfg := &config.Config{
-			TargetDir:   targetDir,
-			PutioFolder: putioFolder,
-			OAuthToken:  oauthToken,
-			ListenAddr:  listenAddr,
-			WorkerCount: workerCount,
+			TargetDir:           targetDir,
+			PutioFolder:         putioFolder,
+			OAuthToken:          oauthToken,
+			ListenAddr:          listenAddr,
+			WorkerCount:         workerCount,
+			DownloadStartWindow: downloadStartWindow,
+		}
+
+		if err := download.ValidateStartWindow(cfg.DownloadStartWindow); err != nil {
+			log.Fatal("config").Err(err).Msg("Invalid download start window configuration")
 		}
 
 		// Initialize Put.io API client
@@ -181,10 +195,16 @@ folder: "plundrio"					# Folder name on Put.io
 token: "" 									# Get a token with get-token
 listen: ":9091"							# Transmission RPC server address
 workers: 4									# Number of download workers
+download_start_window:       # Optional local download start window
+  enabled: false
+  start: "23:00"
+  end: "05:00"
 log_level: "info"					  # Log level (trace,debug,info,warn,error,fatal,panic,none,pretty)
 
 # Environment variables:
-# PLDR_TARGET, PLDR_FOLDER, PLDR_TOKEN, PLDR_LISTEN, PLDR_WORKERS, PLDR_LOG_LEVEL
+# PLDR_TARGET, PLDR_FOLDER, PLDR_TOKEN, PLDR_LISTEN, PLDR_WORKERS,
+# PLDR_DOWNLOAD_START_WINDOW_ENABLED, PLDR_DOWNLOAD_START_WINDOW_START,
+# PLDR_DOWNLOAD_START_WINDOW_END, PLDR_LOG_LEVEL
 `
 
 		outputPath := "plundrio-config.yaml"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,13 @@
 package config
 
+// DownloadStartWindowConfig gates when new local downloads may begin.
+// It only affects the start of local downloads, not ongoing transfers.
+type DownloadStartWindowConfig struct {
+	Enabled bool
+	Start   string
+	End     string
+}
+
 // Config holds the runtime configuration
 type Config struct {
 	// TargetDir is where completed downloads will be stored
@@ -19,4 +27,7 @@ type Config struct {
 
 	// WorkerCount is the number of concurrent download workers (default: 4)
 	WorkerCount int
+
+	// DownloadStartWindow optionally restricts when new local downloads may start.
+	DownloadStartWindow DownloadStartWindowConfig
 }

--- a/internal/download/transfers.go
+++ b/internal/download/transfers.go
@@ -252,6 +252,7 @@ func (p *TransferProcessor) logAllTransfersDetails() {
 // processReadyTransfers handles completed and seeding transfers
 func (p *TransferProcessor) processReadyTransfers() {
 	readyTransfers := append(p.transfers["COMPLETED"], p.transfers["SEEDING"]...)
+	now := time.Now()
 
 	for _, transfer := range readyTransfers {
 		select {
@@ -260,6 +261,15 @@ func (p *TransferProcessor) processReadyTransfers() {
 			return
 		default:
 			if p.isTransferBeingProcessed(transfer.ID) {
+				continue
+			}
+			if !CanStartDownloadNow(p.manager.cfg.DownloadStartWindow, now) {
+				log.Debug("transfers").
+					Int64("transfer_id", transfer.ID).
+					Str("transfer_name", transfer.Name).
+					Str("window_start", p.manager.cfg.DownloadStartWindow.Start).
+					Str("window_end", p.manager.cfg.DownloadStartWindow.End).
+					Msg("Skipping local download start because current time is outside the configured window")
 				continue
 			}
 			p.startTransferProcessing(transfer)

--- a/internal/download/window.go
+++ b/internal/download/window.go
@@ -1,0 +1,65 @@
+package download
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/elsbrock/plundrio/internal/config"
+)
+
+// ValidateStartWindow checks whether the configured download-start window is valid.
+func ValidateStartWindow(window config.DownloadStartWindowConfig) error {
+	if !window.Enabled {
+		return nil
+	}
+
+	if _, err := parseClockMinutes(window.Start); err != nil {
+		return fmt.Errorf("invalid download_start_window.start: %w", err)
+	}
+
+	if _, err := parseClockMinutes(window.End); err != nil {
+		return fmt.Errorf("invalid download_start_window.end: %w", err)
+	}
+
+	return nil
+}
+
+// CanStartDownloadNow reports whether a new local download may start at the supplied time.
+// Existing downloads are unaffected.
+func CanStartDownloadNow(window config.DownloadStartWindowConfig, now time.Time) bool {
+	if !window.Enabled {
+		return true
+	}
+
+	startMinutes, err := parseClockMinutes(window.Start)
+	if err != nil {
+		return false
+	}
+
+	endMinutes, err := parseClockMinutes(window.End)
+	if err != nil {
+		return false
+	}
+
+	nowMinutes := now.Hour()*60 + now.Minute()
+
+	if startMinutes == endMinutes {
+		return true
+	}
+
+	if startMinutes < endMinutes {
+		return nowMinutes >= startMinutes && nowMinutes < endMinutes
+	}
+
+	return nowMinutes >= startMinutes || nowMinutes < endMinutes
+}
+
+func parseClockMinutes(value string) (int, error) {
+	parsed, err := time.Parse("15:04", strings.TrimSpace(value))
+	if err != nil {
+		return 0, fmt.Errorf("expected HH:MM 24-hour time: %q", value)
+	}
+
+	return parsed.Hour()*60 + parsed.Minute(), nil
+}

--- a/internal/download/window_test.go
+++ b/internal/download/window_test.go
@@ -1,0 +1,121 @@
+package download
+
+import (
+	"testing"
+	"time"
+
+	"github.com/elsbrock/plundrio/internal/config"
+)
+
+func TestValidateStartWindow(t *testing.T) {
+	tests := []struct {
+		name    string
+		window  config.DownloadStartWindowConfig
+		wantErr bool
+	}{
+		{
+			name:   "disabled_window_skips_validation",
+			window: config.DownloadStartWindowConfig{},
+		},
+		{
+			name: "valid_window",
+			window: config.DownloadStartWindowConfig{
+				Enabled: true,
+				Start:   "23:00",
+				End:     "05:00",
+			},
+		},
+		{
+			name: "invalid_start",
+			window: config.DownloadStartWindowConfig{
+				Enabled: true,
+				Start:   "25:00",
+				End:     "05:00",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid_end",
+			window: config.DownloadStartWindowConfig{
+				Enabled: true,
+				Start:   "23:00",
+				End:     "banana",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateStartWindow(tt.window)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateStartWindow() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCanStartDownloadNow(t *testing.T) {
+	tests := []struct {
+		name   string
+		window config.DownloadStartWindowConfig
+		now    string
+		want   bool
+	}{
+		{
+			name:   "disabled_window_allows_any_time",
+			window: config.DownloadStartWindowConfig{},
+			now:    "14:30",
+			want:   true,
+		},
+		{
+			name:   "inside_same_day_window",
+			window: config.DownloadStartWindowConfig{Enabled: true, Start: "09:00", End: "17:00"},
+			now:    "11:30",
+			want:   true,
+		},
+		{
+			name:   "outside_same_day_window",
+			window: config.DownloadStartWindowConfig{Enabled: true, Start: "09:00", End: "17:00"},
+			now:    "18:00",
+			want:   false,
+		},
+		{
+			name:   "inside_overnight_window_before_midnight",
+			window: config.DownloadStartWindowConfig{Enabled: true, Start: "23:00", End: "05:00"},
+			now:    "23:30",
+			want:   true,
+		},
+		{
+			name:   "inside_overnight_window_after_midnight",
+			window: config.DownloadStartWindowConfig{Enabled: true, Start: "23:00", End: "05:00"},
+			now:    "04:59",
+			want:   true,
+		},
+		{
+			name:   "outside_overnight_window",
+			window: config.DownloadStartWindowConfig{Enabled: true, Start: "23:00", End: "05:00"},
+			now:    "12:00",
+			want:   false,
+		},
+		{
+			name:   "equal_start_and_end_means_always_allowed",
+			window: config.DownloadStartWindowConfig{Enabled: true, Start: "00:00", End: "00:00"},
+			now:    "12:00",
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now, err := time.Parse("15:04", tt.now)
+			if err != nil {
+				t.Fatalf("time.Parse() error = %v", err)
+			}
+
+			if got := CanStartDownloadNow(tt.window, now); got != tt.want {
+				t.Fatalf("CanStartDownloadNow() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/plundrio-config.yaml
+++ b/plundrio-config.yaml
@@ -6,7 +6,13 @@ folder: "plundrio"					# Folder name on Put.io
 token: "" 									# Get a token with get-token
 listen: ":9091"							# Transmission RPC server address
 workers: 4									# Number of download workers
+download_start_window:       # Optional local download start window
+  enabled: false
+  start: "23:00"
+  end: "05:00"
 log_level: "info"					  # Log level (trace,debug,info,warn,error,fatal,panic,none,pretty)
 
 # Environment variables:
-# PLDR_TARGET, PLDR_FOLDER, PLDR_TOKEN, PLDR_LISTEN, PLDR_WORKERS, PLDR_LOG_LEVEL
+# PLDR_TARGET, PLDR_FOLDER, PLDR_TOKEN, PLDR_LISTEN, PLDR_WORKERS,
+# PLDR_DOWNLOAD_START_WINDOW_ENABLED, PLDR_DOWNLOAD_START_WINDOW_START,
+# PLDR_DOWNLOAD_START_WINDOW_END, PLDR_LOG_LEVEL


### PR DESCRIPTION
## Summary
- add a `download_start_window` config object with `enabled`, `start`, and `end`
- validate the window at startup using `HH:MM` 24-hour times
- gate only the start of new local downloads, while allowing Put.io transfers and in-flight local downloads to continue normally
- document the new config and cover the time-window logic with unit tests

## Why
This keeps the change small and focused for users who want overnight-only local downloads without changing the existing Put.io transfer flow.

## Example config
```yaml
download_start_window:
  enabled: true
  start: "23:00"
  end: "05:00"
```

## Notes
- windows that cross midnight are supported
- existing downloads are not paused or interrupted when the window closes
- `go test ./...` passes
