### PR TITLE
fix: preserve stalled download cancellation for retries

### DIFF
--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -21,6 +21,8 @@ const (
 	baseDownloadRetryDelay = 30 * time.Second
 )
 
+var errDownloadStalled = errors.New("download stalled")
+
 // downloadWorker processes download jobs from the queue
 func (m *Manager) downloadWorker() {
 	for {
@@ -147,6 +149,9 @@ func isTransientError(err error) bool {
 	if err == nil {
 		return false
 	}
+	if errors.Is(err, errDownloadStalled) {
+		return true
+	}
 
 	// Cancellation is deliberate, never transient.
 	var downloadErr *DownloadError
@@ -244,8 +249,8 @@ func (m *Manager) scheduleDownloadRetry(job downloadJob, err error) bool {
 // downloadFile downloads a file from Put.io to the target directory using grab
 func (m *Manager) downloadFile(state *DownloadState) error {
 	// Derive context from manager's lifecycle context
-	ctx, cancel := context.WithCancel(m.Context())
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(m.Context())
+	defer cancel(nil)
 
 	// Get download URL
 	url, err := m.client.GetDownloadURL(ctx, state.FileID)
@@ -320,6 +325,12 @@ func (m *Manager) downloadFile(state *DownloadState) error {
 		close(done)
 		<-monitorStopped
 	}
+	cancellationError := func(reason string) error {
+		if cause := context.Cause(ctx); errors.Is(cause, errDownloadStalled) {
+			return cause
+		}
+		return NewDownloadCancelledError(state.Name, reason)
+	}
 
 	// Wait for completion or cancellation
 	select {
@@ -328,7 +339,7 @@ func (m *Manager) downloadFile(state *DownloadState) error {
 		// Check for errors
 		if err := resp.Err(); err != nil {
 			if ctx.Err() != nil {
-				return NewDownloadCancelledError(state.Name, "download stopped")
+				return cancellationError("download stopped")
 			}
 			return fmt.Errorf("download failed: %w", err)
 		}
@@ -378,6 +389,6 @@ func (m *Manager) downloadFile(state *DownloadState) error {
 
 	case <-ctx.Done():
 		stopMonitor()
-		return NewDownloadCancelledError(state.Name, "context cancelled")
+		return cancellationError("context cancelled")
 	}
 }

--- a/internal/download/download_integration_test.go
+++ b/internal/download/download_integration_test.go
@@ -2,6 +2,7 @@ package download
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -255,6 +256,13 @@ func TestStalledDownloadIsCancelled(t *testing.T) {
 	case err := <-done:
 		if err == nil {
 			t.Fatal("expected the stalled download to fail")
+		}
+		if !errors.Is(err, errDownloadStalled) {
+			t.Fatalf("stalled download error = %v, want errDownloadStalled", err)
+		}
+		var downloadErr *DownloadError
+		if errors.As(err, &downloadErr) && downloadErr.Type == "DownloadCancelled" {
+			t.Fatalf("stalled download was misclassified as shutdown cancellation: %v", err)
 		}
 	case <-time.After(20 * time.Second):
 		t.Fatal("stalled download was never cancelled")

--- a/internal/download/download_test.go
+++ b/internal/download/download_test.go
@@ -40,6 +40,11 @@ func TestIsTransientError(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "download_stalled_error",
+			err:  fmt.Errorf("download attempt failed: %w", errDownloadStalled),
+			want: true,
+		},
+		{
 			name: "connection_reset",
 			err:  errors.New("connection reset"),
 			want: true,

--- a/internal/download/progress.go
+++ b/internal/download/progress.go
@@ -22,7 +22,7 @@ func (m *Manager) trackDownloadProgress(
 	resp *grab.Response,
 	done <-chan struct{},
 	progressTicker *time.Ticker,
-	cancelDownload context.CancelFunc,
+	cancelDownload context.CancelCauseFunc,
 ) {
 	log.Info("download").
 		Str("file_name", state.Name).
@@ -110,7 +110,7 @@ func (m *Manager) trackDownloadProgress(
 					Str("file_name", state.Name).
 					Dur("stalled_for", stalled).
 					Msg("Download stalled, cancelling")
-				cancelDownload()
+				cancelDownload(errDownloadStalled)
 				return
 			}
 		case <-ctx.Done():


### PR DESCRIPTION
When the download progress monitor cancels a stalled attempt, the cancellation currently looks like a deliberate shutdown and bypasses the transient retry path. Preserve an explicit stall cause with `context.WithCancelCause` so stalled attempts remain retryable and ordinary shutdown cancellation remains non-transient.

Extends the paced HTTP stall regression and transient-error table to verify that distinction. This is an independent fix against `main`; sustained-stall RPC reporting is separate.

Extracted from #52 for independent review and landing ahead of the manifest
feature. #53 is the other independent prerequisite. Order: #53 and #54 → #52
→ #49 → #50 → #51 only if its product scope is accepted. Ready for review.

Validation: `go test ./...`, `go test -race ./...`, `go vet ./...`, `go build ./...`, and `git diff --check` all passed locally on Go 1.27.1 (darwin/arm64). The stalled cancellation regression was previously confirmed to fail against the original implementation. No deployment or live service changes were performed.
